### PR TITLE
Internal Ontology File

### DIFF
--- a/config/ontologies-internal.json
+++ b/config/ontologies-internal.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "Human Phenotype Ontology",
+    "prefix": "hp",
+    "github": {
+      "api":  "https://api.github.com/repos/obophenotype/human-phenotype-ontology",
+      "home": "https://github.com/obophenotype/human-phenotype-ontology"
+    },
+    "home": "https://hpo.jax.org",
+    "api": {
+      "docs": "https://ontology.jax.org/api/hp/docs",
+      "base":  "https://ontology.jax.org/api/hp"
+    },
+    "base_file": "https://purl.obolibrary.org/obo/hp/hp-base.json",
+    "international": true,
+    "description": "The Human Phenotype Ontology (HPO) provides a standardized vocabulary of phenotypic abnormalities encountered in human disease."
+  },
+  {
+    "name": "Medical Action Ontology",
+    "prefix": "maxo",
+    "github": {
+      "api":  "https://api.github.com/repos/monarch-initiative/maxo",
+      "home": "https://github.com/monarch-initiative/MAxO"
+    },
+    "home": "https://github.com/monarch-initiative/MAxO",
+    "api": {
+      "docs": "https://ontology.jax.org/api/maxo/docs",
+      "base": "https://ontology.jax.org/api/maxo"
+    },
+    "base_file": "https://purl.obolibrary.org/obo/maxo/maxo-base.json",
+    "international": false,
+    "description": "The Medical Action Ontology (MAxO) provides a broad view of medical actions and includes terms for medical procedures, interventions, therapies, treatments, and recommendations."
+  },
+  {
+    "name": "Mondo Disease Ontology",
+    "prefix": "mondo",
+    "github": {
+      "api":  "https://api.github.com/repos/monarch-initiative/mondo",
+      "home": "https://github.com/monarch-initiative/mondo"
+    },
+    "home": "https://mondo.monarchinitiative.org/",
+    "api": {
+      "docs": "https://ontology.jax.org/api/mondo/docs",
+      "base": "https://ontology.jax.org/api/mondo"
+    },
+    "base_file": "https://purl.obolibrary.org/obo/mondo/mondo-base.json",
+    "international": false,
+    "description": "The Mondo Disease Ontology (Mondo) aims to harmonize disease definitions across the world. The name Mondo comes from the latin word 'mundus' and means 'for the world.'"
+  },
+  {
+    "name": "Mammalian Phenotype Ontology",
+    "prefix": "mp",
+    "github": {
+      "api":  "https://api.github.com/repos/mgijax/mammalian-phenotype-ontology",
+      "home": "https://github.com/mgijax/mammalian-phenotype-ontology"
+    },
+    "home": "https://www.informatics.jax.org/vocab/mp_ontology",
+    "api": {
+      "docs": "https://ontology.jax.org/api/mp/docs",
+      "base": "https://ontology.jax.org/api/mp"
+    },
+    "base_file": "https://purl.obolibrary.org/obo/mp/mp-base.json",
+    "international": false,
+    "description": "The Mammalian Phenotype Ontology (MP) provides a standardized vocabulary of phenotypic abnormalities encountered in Mus musculus."
+  },
+  {
+    "name": "Cell Ontology",
+    "prefix": "cl",
+    "github": {
+      "api":  "https://api.github.com/repos/obophenotype/cell-ontology",
+      "home": "https://github.com/obophenotype/cell-ontology"
+    },
+    "home": "https://obophenotype.github.io/cell-ontology/",
+    "api": {
+      "docs": "https://ontology.jax.org/api/cl/docs",
+      "base": "https://ontology.jax.org/api/cl"
+    },
+    "base_file": "https://purl.obolibrary.org/obo/cl/cl-base.json",
+    "international": false,
+    "description": "The Cell Ontology (CL) is an OBO Foundry ontology covering the domain of canonical, natural biological cell types."
+  }
+]


### PR DESCRIPTION
Before making breaking changes, we want to create a separate file for internal deployments of this service and also to support [this](https://github.com/TheJacksonLaboratory/jds-ui-components/pull/1)

